### PR TITLE
Tweaks to English dictionary

### DIFF
--- a/lib/dictionary-en.ts
+++ b/lib/dictionary-en.ts
@@ -691,7 +691,7 @@ Spy
 Square
 Squash
 Squirrel
-St.Patrick
+St. Patrick
 Stable
 Stadium
 Staff

--- a/lib/dictionary-en.ts
+++ b/lib/dictionary-en.ts
@@ -772,7 +772,6 @@ Tutu
 Tuxedo
 Undertaker
 Unicorn
-Univerity
 University
 Vacuum
 Valentine

--- a/lib/dictionary-en.ts
+++ b/lib/dictionary-en.ts
@@ -380,7 +380,6 @@ Knife
 Knight
 Knot
 Kung Fu
-Kung fu
 Lab
 Lace
 Ladder


### PR DESCRIPTION
Removed a duplicate, removed a typo'd word, and fixed the punctuation of `St. Patrick`.